### PR TITLE
Add variable serving size to salvajes

### DIFF
--- a/P6/salvajes.c
+++ b/P6/salvajes.c
@@ -26,6 +26,10 @@
 // Número de veces que cada salvaje come
 #define NUMITER  3
 
+// Cantidad de raciones que consume en cada iteración (por defecto 1, se puede
+// modificar mediante argumento de línea de órdenes)
+static int portion_size = 1;
+
 static sem_t *mutex_sem = NULL;
 static sem_t *full_sem  = NULL;
 static sem_t *empty_sem = NULL;
@@ -60,9 +64,9 @@ int getServingsFromPot(void) {
 }
 
 // Simula comer: imprime mensaje y duerme un tiempo aleatorio
-void eat(void) {
+void eat(int amount) {
     pid_t id = getpid();
-    printf("Savage %d: eating\n", id);
+    printf("Savage %d: eating %d serving(s)\n", id, amount);
     sleep(rand() % 5 + 1);
 }
 
@@ -70,12 +74,21 @@ void eat(void) {
 void savages(void) {
     srand(getpid());  // semilla distinta por proceso
     for (int i = 0; i < NUMITER; i++) {
-        getServingsFromPot();
-        eat();
+        for (int j = 0; j < portion_size; j++) {
+            getServingsFromPot();
+        }
+        eat(portion_size);
     }
 }
 
-int main(void) {
+int main(int argc, char *argv[]) {
+    if (argc > 1) {
+        portion_size = atoi(argv[1]);
+        if (portion_size <= 0) {
+            fprintf(stderr, "Invalid portion size: %s\n", argv[1]);
+            return EXIT_FAILURE;
+        }
+    }
     // 1) Abrir memoria compartida existente
     shm_fd = shm_open(SHM_NAME, O_RDWR, 0);
     if (shm_fd < 0) {


### PR DESCRIPTION
## Summary
- allow specifying how many servings each savage eats on each iteration via a command line argument
- print the amount eaten in `eat`

## Testing
- `make -C P6 clean all`
- run `./cocinero` and `./salvajes 2` to verify new argument works

------
https://chatgpt.com/codex/tasks/task_e_6841e3d4d224832c8fe0bd5c2e652751